### PR TITLE
Fixes #11 serve without ssl to allow port forwarding in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Answers required during `azd up`:
 
 ```bash
 cd ng-web
-ng s --ssl --host localhost
+ng s --host localhost
 ```
 
 ℹ️ if you are running local ensure that the [Angular CLI](https://angular.dev/tools/cli#) is installed `npm install -g @angular/cli`
@@ -128,7 +128,7 @@ ng s --ssl --host localhost
 
 ### Accessing Azure OpenAI from your local machine
 
-The Azure OpenAI resource provisioned by `azd up` has **public network access disabled** and is reachable only through its private endpoint inside the VNet. If you run the **Function locally** (so the call to Azure OpenAI originates from your machine) you can temporarily enable full public network access or enable public access for your current IP in the portal
+The Azure OpenAI resource provisioned by `azd up` has **public network access disabled** and is reachable only through its private endpoint inside the VNet. If you run the **Function locally** (so the call to Azure OpenAI originates from your machine) you can temporarily enable full public network access or enable public access for your current IP in the portal (note changes may take several minutes to take effect)
 
 ![azd up completed](./docs/cod-networking.png)
 


### PR DESCRIPTION
Changed the readme to ng s --host localhost to avoid issues with port forwarding when working with codespace in the browser.